### PR TITLE
Removed highly annoying 'Thank you' message.

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/Chisel.java
+++ b/src/main/java/com/cricketcraft/chisel/Chisel.java
@@ -199,16 +199,4 @@ public class Chisel {
 			Configurations.refreshConfig();
 		}
 	}
-
-	@SubscribeEvent
-	public void thankYou(EntityJoinWorldEvent event){
-		if(!event.world.isRemote && event.entity instanceof EntityPlayerMP){
-			EntityPlayerMP player = (EntityPlayerMP) event.entity;
-			if(!player.getEntityData().getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG).getBoolean("thanked")){
-				NBTTagCompound tag = player.getEntityData().getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG);
-				tag.setBoolean("thanked", true);
-				player.addChatMessage(new ChatComponentText("Thank you for half a million downloads! - The Chisel Team"));
-			}
-		}
-	}
 }


### PR DESCRIPTION
Yes, we understand that you guys are grateful for all those downloads, but seeing that message each time I make a new world, join a new server or reset my player data is way too much. In addition this is unnecessary cluttering of player NBT data and it is a piece of unnecessary code that gets in the way of performance optimization.
Adding a 'Thank you' message on the forums or other download places would have been a better choice in my opinion.